### PR TITLE
Block marks wrapping behaviour

### DIFF
--- a/text/0008-block-marks-wrapping.md
+++ b/text/0008-block-marks-wrapping.md
@@ -1,0 +1,88 @@
+# Summary
+
+Provide the ability to use block marks for positioning UI elements. Please read the discussion here: https://discuss.prosemirror.net/t/block-marks-wrapping-behaviour/1718/3
+
+# Motivation
+
+Currently, there's an optimisation step in `prosemirror-view` that allows ProseMirror to reuse existing mark views if two marks applied on adjacent block nodes are identical. Here's an example of ProseMirror document:
+
+```
+{
+  "version": 1,
+  "type": "doc",
+  "content": [
+    {
+      "type": "p",
+      "content": [
+        {
+          "type": "text",
+          "text": "text"
+        }
+      ],
+      "marks": [
+        {
+          "type": "breakout",
+          "attrs": {
+            "mode": "wide"
+          }
+        }
+      ]
+    },
+    {
+      "type": "p",
+      "content": [
+        {
+          "type": "text",
+          "text": "more text"
+        }
+      ],
+      "marks": [
+        {
+          "type": "breakout",
+          "attrs": {
+            "mode": "wide"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Resulting html:
+
+```
+<div class="breakout_mark">
+  <p>text</p>
+  <p>more text</p>
+</div>
+```
+
+This behaviour makes it hard to vertically position UI elements relatively to the second paragraph as the mark DOM node wraps both paragraphs.
+
+The suggestion is to control the wrapping behaviour so that we can have the following DOM structure:
+
+```
+<div class="breakout_mark">
+  <p>text</p>
+</div>
+<div class="breakout_mark">
+  <p>more text</p>
+</div>
+```
+
+# Guide-level explanation
+
+One way to accomplish this would be to provide the ability to control the wrapping behaviour of block marks from nodeViews.
+
+The proposal gives the `NodeView` class a new getter:
+
+**`disableWrapping`**`: boolean` indicates whether `prosemirror-view` uses the wrapping optimisation.
+
+Implementation details: https://github.com/ProseMirror/prosemirror-view/pull/43
+
+# Drawbacks
+
+When this feature is used, ProseMirror will generate an extra markup needed to wrap each block node with its own block mark.
+
+Also, since it is expected to work only for block marks, we should make it very clear in ProseMirror documentation.

--- a/text/0008-block-marks-wrapping.md
+++ b/text/0008-block-marks-wrapping.md
@@ -73,16 +73,16 @@ The suggestion is to control the wrapping behaviour so that we can have the foll
 
 # Guide-level explanation
 
-One way to accomplish this would be to provide the ability to control the wrapping behaviour of block marks from nodeViews.
+The proposal gives the `MarkSpec` a new getter:
 
-The proposal gives the `NodeView` class a new getter:
-
-**`disableWrapping`**`: boolean` indicates whether `prosemirror-view` uses the wrapping optimisation.
+**`spanning`**`: boolean` indicates whether `prosemirror-view` uses the wrapping optimisation. We will preserve the default behaviour unless its set to `false`.
 
 Implementation details: https://github.com/ProseMirror/prosemirror-view/pull/43
 
 # Drawbacks
 
-When this feature is used, ProseMirror will generate an extra markup needed to wrap each block node with its own block mark.
+When this feature is used, ProseMirror will generate an extra markup needed to wrap each node with its own mark.
 
-Also, since it is expected to work only for block marks, we should make it very clear in ProseMirror documentation.
+# Rationale and alternatives
+
+Originally I though about using mark nodeviews for that, but this feature should be available from HTML serializer when marks don't have a nodeview.


### PR DESCRIPTION
Introduce the `disableWrapping` property in `NodeView` class that would control the wrapping behaviour of  block marks.

[Forum discussion](https://discuss.prosemirror.net/t/block-marks-wrapping-behaviour/1718/3)

[Rendered RFC](https://github.com/eshvedai/rfcs/blob/eshvedai/block-marks-wrapping/text/0008-block-marks-wrapping.md)